### PR TITLE
Prevent console window from opening on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "exiftool"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "assert_matches",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exiftool"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "A Rust wrapper for ExifTool."

--- a/examples/batch_read.rs
+++ b/examples/batch_read.rs
@@ -25,12 +25,12 @@ fn main() -> Result<(), ExifToolError> {
     let img_dir_path = Path::new(IMAGE_DIR);
 
     let paths = find_images_in_dir(img_dir_path).unwrap_or_else(|e| {
-        eprintln!("Failed to read image dir '{}': {}", IMAGE_DIR, e);
+        eprintln!("Failed to read image dir '{IMAGE_DIR}': {e}");
         Vec::new()
     });
 
     if paths.is_empty() {
-        println!("No images found in '{}'. Exiting.", IMAGE_DIR);
+        println!("No images found in '{IMAGE_DIR}'. Exiting.");
         return Ok(());
     }
 

--- a/examples/read_all_metadata.rs
+++ b/examples/read_all_metadata.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), ExifToolError> {
     // The provided ExifData struct requires `-g2`
     println!("\n--- Reading all metadata into ExifData (-g2) ---");
     let exif_data: ExifData = et.read_metadata(path, &["-g2"])?;
-    println!("{:#?}", exif_data);
+    println!("{exif_data:#?}");
 
     Ok(())
 }

--- a/examples/read_tag.rs
+++ b/examples/read_tag.rs
@@ -9,27 +9,24 @@ fn main() -> Result<(), ExifToolError> {
 
     // 1. Read as raw JSON Value
     let make_json = et.json_tag(path, "Make")?;
-    println!("Make (JSON): {}", make_json); // Output: "LG Electronics"
+    println!("Make (JSON): {make_json}"); // Output: "LG Electronics"
 
     // 2. Read and deserialize into String
     let model: String = et.read_tag(path, "Model")?;
-    println!("Model (String): {}", model); // Output: LG-H815
+    println!("Model (String): {model}"); // Output: LG-H815
 
     // 3. Read existing tag into Option<T>
     let width_opt: Option<u32> = et.read_tag(path, "ImageWidth")?;
-    println!("Width (Option<u32>): {:?}", width_opt); // Output: Some(5312)
+    println!("Width (Option<u32>): {width_opt:?}"); // Output: Some(5312)
 
     // 4. Read non-existent tag into Option<T> -> Ok(None)
     let comment_opt: Option<String> = et.read_tag(path, "NonExistentTag")?;
-    println!("NonExistentTag (Option<String>): {:?}", comment_opt); // Output: None
+    println!("NonExistentTag (Option<String>): {comment_opt:?}"); // Output: None
 
     // 5. Attempting to read non-existent tag into String -> Err(TagNotFound)
     match et.read_tag::<String>(path, "NonExistentTag") {
         Err(ExifToolError::TagNotFound { tag, .. }) => {
-            println!(
-                "Correctly failed to read required tag '{}': TagNotFound",
-                tag
-            );
+            println!("Correctly failed to read required tag '{tag}': TagNotFound");
         }
         _ => panic!("Expected TagNotFound!"),
     }

--- a/examples/read_tags_typed.rs
+++ b/examples/read_tags_typed.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), exiftool::ExifToolError> {
     // Read only these tags and deserialize
     let info: CameraInfo = et.read_tags(path, &tags)?;
 
-    println!("Read specific tags into struct:\n{:#?}", info);
+    println!("Read specific tags into struct:\n{info:#?}");
     // Output:
     // Read specific tags into struct:
     // CameraInfo {

--- a/examples/write_tags.rs
+++ b/examples/write_tags.rs
@@ -25,13 +25,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Write String tag
     et.write_tag(&temp_file, "UserComment", "Hello from exiftool-rs!", &args)?;
     let comment: String = et.read_tag(&temp_file, "UserComment")?;
-    println!("Wrote and read back comment: '{}'", comment);
+    println!("Wrote and read back comment: '{comment}'");
     assert_eq!(comment, "Hello from exiftool-rs!");
 
     // 2. Write Numeric tag
     et.write_tag(&temp_file, "Rating", 5, &args)?;
     let rating: u8 = et.read_tag(&temp_file, "Rating")?;
-    println!("Wrote and read back rating: {}", rating);
+    println!("Wrote and read back rating: {rating}");
     assert_eq!(rating, 5);
 
     // 3. Write Binary tag (tiny dummy JPEG)

--- a/src/exiftool.rs
+++ b/src/exiftool.rs
@@ -116,16 +116,29 @@ impl ExifTool {
     /// # }
     /// ```
     pub fn with_executable(exiftool_path: &Path) -> Result<Self, ExifToolError> {
-        let mut child = Command::new(exiftool_path)
+        let mut command = Command::new(exiftool_path);
+
+        command
             .arg("-stay_open")
             .arg("True")
             .arg("-@")
             .arg("-") // Read command args from stdin
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(ExifToolError::ExifToolNotFound)?;
+            .stderr(Stdio::piped());
+
+        #[cfg(windows)]
+        {
+            // When running an application with `windows_subsystem = "windows"`
+            // spawning a `Command` will open a console window by default.
+            //
+            // We don't want that, so we suppress it with a creation flag.
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            command.creation_flags(CREATE_NO_WINDOW);
+        }
+
+        let mut child = command.spawn().map_err(ExifToolError::ExifToolNotFound)?;
 
         let stdin = child
             .stdin

--- a/src/exiftool.rs
+++ b/src/exiftool.rs
@@ -204,7 +204,7 @@ impl ExifTool {
 
         // 2. Send command arguments line-by-line
         for arg in args {
-            writeln!(self.stdin, "{}", arg)?;
+            writeln!(self.stdin, "{arg}")?;
         }
         // 3. Send the execute signal
         writeln!(self.stdin, "-execute")?;
@@ -236,7 +236,7 @@ impl ExifTool {
                         command_args,
                     });
                 } else if err_line.contains("Warning:") {
-                    warn!("ExifTool Warning - {}", err_line);
+                    warn!("ExifTool Warning - {err_line}");
                 }
             }
         }
@@ -652,7 +652,7 @@ impl ExifTool {
         file_path: &Path,
         tags: &[&str],
     ) -> Result<T, ExifToolError> {
-        let tag_args: Vec<String> = tags.iter().map(|t| format!("-{}", t)).collect();
+        let tag_args: Vec<String> = tags.iter().map(|t| format!("-{t}")).collect();
         let tag_args_str: Vec<&str> = tag_args.iter().map(String::as_str).collect();
 
         let value = self.json(file_path, &tag_args_str)?;
@@ -790,7 +790,7 @@ impl ExifTool {
     /// # }
     /// ```
     pub fn json_tag(&mut self, file_path: &Path, tag: &str) -> Result<Value, ExifToolError> {
-        let tag_arg = format!("-{}", tag);
+        let tag_arg = format!("-{tag}");
         // Read *only* this tag using the metadata endpoint
         let metadata_json = self.json(file_path, &[&tag_arg])?;
 
@@ -966,7 +966,7 @@ impl ExifTool {
         file_path: &Path,
         tag: &str,
     ) -> Result<Vec<u8>, ExifToolError> {
-        let tag_arg = format!("-{}", tag);
+        let tag_arg = format!("-{tag}");
         let path_str = file_path.to_string_lossy();
         let args = [path_str.as_ref(), "-b", &tag_arg];
 
@@ -1063,7 +1063,7 @@ impl ExifTool {
     ) -> Result<(), ExifToolError> {
         let value_str = value.to_string();
         // Format the core argument: -TAG=VALUE
-        let tag_arg = format!("-{}={}", tag, value_str);
+        let tag_arg = format!("-{tag}={value_str}");
 
         let path_str = file_path.to_string_lossy();
 
@@ -1159,7 +1159,7 @@ impl ExifTool {
         let temp_path_str = temp_file.path().to_string_lossy();
 
         // Construct the field argument with the '<=' operator.
-        let tag_arg = format!("-{}<={}", tag, temp_path_str);
+        let tag_arg = format!("-{tag}<={temp_path_str}");
 
         let file_path_str = file_path.to_string_lossy();
         let mut args = vec![tag_arg.as_str()];
@@ -1179,17 +1179,14 @@ impl Drop for ExifTool {
         // 1. Attempt graceful shutdown by sending exit commands.
         if let Err(e) = self.close() {
             // Log if closing failed, but proceed to kill anyway.
-            warn!("Failed to send close command to exiftool process: {}", e);
+            warn!("Failed to send close command to exiftool process: {e}",);
         }
 
         // 2. Kill the process. This ensures cleanup even if graceful shutdown fails
         //    or hangs. `kill()` on Unix sends SIGKILL; on Windows, TerminateProcess.
         if let Err(e) = self.child.kill() {
             // Log if killing failed (e.g., process already dead).
-            warn!(
-                "Failed to kill exiftool process (may already be dead): {}",
-                e
-            );
+            warn!("Failed to kill exiftool process (may already be dead): {e}");
         }
 
         // 3. Wait for the process to fully terminate and release resources.
@@ -1197,10 +1194,10 @@ impl Drop for ExifTool {
         //    attempted to kill it.
         match self.child.wait() {
             Ok(status) => {
-                log::debug!("Exiftool process exited with status: {}", status);
+                log::debug!("Exiftool process exited with status: {status}");
             }
             Err(e) => {
-                warn!("Failed to wait on exiftool child process: {}", e);
+                warn!("Failed to wait on exiftool child process: {e}");
             }
         }
         log::debug!("ExifTool instance dropped and process cleanup attempted.");
@@ -1516,8 +1513,7 @@ mod tests {
                 .map(PathBuf::from);
             assert!(
                 source_file.is_some(),
-                "SourceFile missing in result for index {}",
-                i
+                "SourceFile missing in result for index {i}"
             );
             // Note: Comparing paths directly can be tricky due to CWD differences.
             // Compare basenames or canonicalize if needed, but checking existence is good.

--- a/src/parse_fn/date.rs
+++ b/src/parse_fn/date.rs
@@ -15,13 +15,12 @@ where
                 // Try parsing the string as a NaiveDate
                 NaiveDate::parse_from_str(&s, "%Y:%m:%d")
                     .map(Some)
-                    .map_err(|_| serde::de::Error::custom(format!("invalid date format: {}", s)))
+                    .map_err(|_| serde::de::Error::custom(format!("invalid date format: {s}")))
             }
             Value::Number(_) => Ok(None), // Gracefully skip numbers
             Value::Null => Ok(None),
             other => Err(serde::de::Error::custom(format!(
-                "unexpected type for date: {:?}",
-                other
+                "unexpected type for date: {other:?}"
             ))),
         }
     } else {

--- a/src/parse_fn/undef_or_float.rs
+++ b/src/parse_fn/undef_or_float.rs
@@ -18,7 +18,7 @@ where
                     Ok(None)
                 } else {
                     s.parse::<f64>().map(Some).map_err(|_| {
-                        de::Error::custom(format!("string can't be parsed to f64: {}", s))
+                        de::Error::custom(format!("string can't be parsed to f64: {s}"))
                     })
                 }
             }
@@ -28,8 +28,7 @@ where
                 .map(Some),
             Value::Null => Ok(None),
             other => Err(de::Error::custom(format!(
-                "unexpected type for float: {:?}",
-                other
+                "unexpected type for float: {other}"
             ))),
         }
     } else {


### PR DESCRIPTION
Thank you for creating this library! I didn't know about `-stay_open` before, this is great! It also avoids the issues on Windows with command argument reencoding!

Currently on Windows with `windows_subsystem = "windows"`, when you create a new `ExifTool` a console window opens. That's just annoying, so I've set the creation flag so no console window appears.